### PR TITLE
replaced app_key with service_id in auth call

### DIFF
--- a/oauth2/client-credentials-flow/token-generation/nginx.conf
+++ b/oauth2/client-credentials-flow/token-generation/nginx.conf
@@ -57,7 +57,7 @@ http {
       set $provider_key CHANGE_ME_PROVIDER_KEY;
       set $service_id CHANGE_ME_SERVICE_ID;
       proxy_ignore_client_abort on;
-      proxy_pass http://threescale_backend/transactions/oauth_authorize.xml?provider_key=$provider_key&app_id=$arg_app_id&service_id=$service_id;
+      proxy_pass http://threescale_backend/transactions/oauth_authorize.xml?provider_key=$provider_key&app_id=$arg_app_id&app_key=$arg_app_key&service_id=$service_id;
     }
 
     location /_threescale/toauth_authorize {


### PR DESCRIPTION
Before the fix:
The request fails with "Authenticated failed" error as it was not sending the service_id for the auth call

With fix:
The request is successful with no error for the application id.
