### PR TITLE
Fix provider key and secret token for implicit grant flow

### DIFF
--- a/oauth2/implicit-flow/token-generation/authorized_callback.lua
+++ b/oauth2/implicit-flow/token-generation/authorized_callback.lua
@@ -40,7 +40,7 @@ end
 local params = ngx.req.get_uri_args()
 
 if ts.required_params_present({'state', 'secret_token'}, params) then
-  if params.secret_token ~= service.secret_token then
+  if params.secret_token ~= service_CHANGE_ME_SERVICE_ID.secret_token then
     ts.error("Secret Token does not match")
   end
 

--- a/oauth2/implicit-flow/token-generation/nginx.conf
+++ b/oauth2/implicit-flow/token-generation/nginx.conf
@@ -71,6 +71,7 @@ http {
     }
 
     location /callback {
+      set $provider_key CHANGE_ME_PROVIDER_KEY;
       set $service_id CHANGE_ME_SERVICE_ID;
       content_by_lua_file 'CHANGE_ME_PATH/authorized_callback.lua';
     }


### PR DESCRIPTION
1) If provider key not given in /callback, results nginx to sent empty provider key

tcpdump on nginx gateway:
If not given, provider_key is sent in empty. tcpdump trace
00e0:  696e 673a 2067 7a69 702c 6465 666c 6174  ing:.gzip,deflat
	0x00f0:  650d 0a55 7365 722d 4167 656e 743a 2041  e..User-Agent:.A
	0x0100:  7061 6368 652d 4874 7470 436c 6965 6e74  pache-HttpClient
	0x0110:  2f34 2e31 2e31 2028 6a61 7661 2031 2e35  /4.1.1.(java.1.5
	0x0120:  290d 0a0d 0a70 726f 7669 6465 725f 6b65  )....provider_ke
	0x0130:  793d 2661 7070 5f69 643d 6538 3130 3964  y=&app_id=e8109d
	0x0140:  6164 2674 6f6b 656e 3d62 6462 6564 6662  ad&token=bdbedfb
	0x0150:  6135 3665 3765 3239 6266 3733 6262 3936  a56e7e29bf73bb96
	0x0160:  6230 3437 6637 6636 6234 3262 6364 3633  b047f7f6b42bcd63
	0x0170:  39 

2)  If service_CHANGE_ME_SERVICE_ID.secret_token​ not given, results in below error in nginx logs

015/03/31 02:49:58 [error] 23527#0: *1 lua entry thread aborted: runtime error: ...nx/customers/implicit-grant-flow/authorized_callback.lua:45: attempt to index global 'service' (a nil value)
stack traceback:
coroutine 0:
	...nx/customers/implicit-grant-flow/authorized_callback.lua: in function <...nx/customers/implicit-grant-flow/authorized_callback.lua:1>, client: 10.0.0.8, server: 10.0.0.11, request: "GET /callback?state=a054dea904c7ade23c502faf90b636ce9aa2d87b&secret_token=123456 HTTP/1.1", host: "10.0.0.11"