### PR TITLE
Add the proxy method to POST proxy passes

### DIFF
--- a/oauth2/authorization-code-flow/no-token-generation/nginx.conf
+++ b/oauth2/authorization-code-flow/no-token-generation/nginx.conf
@@ -37,6 +37,7 @@ http {
       proxy_set_header  Host "su1.3scale.net"; #needed. backend discards other hosts
       set $provider_key CHANGE_ME_PROVIDER_KEY;
       set $service_id CHANGE_ME_SERVICE_ID;
+      proxy_method POST;
       proxy_pass https://threescale_backend/services/$service_id/oauth_access_tokens.xml;
     }
 
@@ -69,6 +70,7 @@ http {
       proxy_set_header  Host "su1.3scale.net";
       set $provider_key CHANGE_ME_PROVIDER_KEY;
       set $service_id CHANGE_ME_SERVICE_ID;
+      proxy_method POST;
       proxy_pass https://threescale_backend/transactions.xml?provider_key=$provider_key&service_id=$service_id&transactions[0][access_token]=$arg_access_token&$usage;
     }
 
@@ -81,6 +83,7 @@ http {
       proxy_set_header  Host $http_host;
       proxy_set_header  Content-Type "application/x-www-form-urlencoded";
       set $provider_key CHANGE_ME_PROVIDER_KEY;
+      # change the path to the get_token.lua path in your environment
       content_by_lua_file /CHANGE_ME_PATH_TO/get_token.lua ;
     }
 

--- a/oauth2/authorization-code-flow/token-generation/nginx.conf
+++ b/oauth2/authorization-code-flow/token-generation/nginx.conf
@@ -47,6 +47,7 @@ http {
       proxy_set_header  Host "su1.3scale.net"; #needed. backend discards other hosts
       set $provider_key CHANGE_ME_PROVIDER_KEY;
       set $service_id CHANGE_ME_SERVICE_ID;
+      proxy_method POST;
       proxy_pass https://threescale_backend/services/$service_id/oauth_access_tokens.xml;
     }
 
@@ -77,7 +78,7 @@ http {
       proxy_set_header  X-Real-IP  $remote_addr;
       proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header  Host "su1.3scale.net";
-
+      proxy_method POST;
       set $provider_key CHANGE_ME_PROVIDER_KEY;
       set $service_id CHANGE_ME_SERVICE_ID;
       proxy_pass https://threescale_backend/transactions.xml?provider_key=$provider_key&service_id=$service_id&transactions[0][access_token]=$arg_access_token&$usage;

--- a/oauth2/client-credentials-flow/no-token-generation/nginx.conf
+++ b/oauth2/client-credentials-flow/no-token-generation/nginx.conf
@@ -89,8 +89,7 @@ http {
       proxy_set_header  Host "su1.3scale.net";
       set $provider_key CHANGE_ME_PROVIDER_KEY;
       set $service_id CHANGE_ME_SERVICE_ID;
-      proxy_method POST;s
-      
+      proxy_method POST;
       proxy_pass https://threescale_backend/transactions.xml?provider_key=$provider_key&service_id=$service_id&transactions[0][access_token]=$arg_access_token&$usage;
     }
 

--- a/oauth2/client-credentials-flow/no-token-generation/nginx.conf
+++ b/oauth2/client-credentials-flow/no-token-generation/nginx.conf
@@ -55,6 +55,7 @@ http {
       proxy_set_header  Host "su1.3scale.net"; #needed. backend discards other hosts
       set $provider_key CHANGE_ME_PROVIDER_KEY;
       set $service_id CHANGE_ME_SERVICE_ID;
+      proxy_method POST;
       proxy_pass https://threescale_backend/services/$service_id/oauth_access_tokens.xml;
     }
 
@@ -88,6 +89,8 @@ http {
       proxy_set_header  Host "su1.3scale.net";
       set $provider_key CHANGE_ME_PROVIDER_KEY;
       set $service_id CHANGE_ME_SERVICE_ID;
+      proxy_method POST;s
+      
       proxy_pass https://threescale_backend/transactions.xml?provider_key=$provider_key&service_id=$service_id&transactions[0][access_token]=$arg_access_token&$usage;
     }
 

--- a/oauth2/client-credentials-flow/token-generation/nginx.conf
+++ b/oauth2/client-credentials-flow/token-generation/nginx.conf
@@ -47,7 +47,7 @@ http {
       set $provider_key CHANGE_ME_PROVIDER_KEY;
       set $service_id CHANGE_ME_SERVICE_ID;
       proxy_method POST;
-      proxy_pass https://threescale_backend/services/$service_ioauth_access_tokensd/oauth_access_tokens.xml;
+      proxy_pass https://threescale_backend/services/$service_id/oauth_access_tokens.xml;
     }
 
     location /_threescale/auth {

--- a/oauth2/client-credentials-flow/token-generation/nginx.conf
+++ b/oauth2/client-credentials-flow/token-generation/nginx.conf
@@ -46,7 +46,8 @@ http {
       proxy_set_header  Host "su1.3scale.net"; #needed. backend discards other hosts
       set $provider_key CHANGE_ME_PROVIDER_KEY;
       set $service_id CHANGE_ME_SERVICE_ID;
-      proxy_pass https://threescale_backend/services/$service_id/oauth_access_tokens.xml;
+      proxy_method POST;
+      proxy_pass https://threescale_backend/services/$service_ioauth_access_tokensd/oauth_access_tokens.xml;
     }
 
     location /_threescale/auth {
@@ -79,6 +80,7 @@ http {
       proxy_set_header  Host "su1.3scale.net";
       set $provider_key CHANGE_ME_PROVIDER_KEY;
       set $service_id CHANGE_ME_SERVICE_ID;
+      proxy_method POST;
       proxy_pass https://threescale_backend/transactions.xml?provider_key=$provider_key&service_id=$service_id&transactions[0][access_token]=$arg_access_token&$usage;
     }
 

--- a/oauth2/implicit-flow/token-generation/nginx.conf
+++ b/oauth2/implicit-flow/token-generation/nginx.conf
@@ -48,6 +48,7 @@ http {
       proxy_set_header  Host "su1.3scale.net"; #needed. backend discards other hosts
       set $provider_key CHANGE_ME_PROVIDER_KEY;
       set $service_id CHANGE_ME_SERVICE_ID;
+      proxy_method POST;
       proxy_pass https://threescale_backend/services/$service_id/oauth_access_tokens.xml;
     }
 
@@ -85,6 +86,7 @@ http {
       proxy_set_header  Host "su1.3scale.net";
       set $provider_key CHANGE_ME_PROVIDER_KEY;
       set $service_id CHANGE_ME_SERVICE_ID;
+      proxy_method POST;
       proxy_pass https://threescale_backend/transactions.xml?provider_key=$provider_key&service_id=$service_id&transactions[0][access_token]=$arg_access_token&$usage;
     }
 

--- a/oauth2/resource-owner-password-flow/no-token-generation/nginx.conf
+++ b/oauth2/resource-owner-password-flow/no-token-generation/nginx.conf
@@ -55,6 +55,7 @@ http {
       proxy_set_header  Host "su1.3scale.net"; #needed. backend discards other hosts
       set $provider_key CHANGE_ME_PROVIDER_KEY;
       set $service_id CHANGE_ME_SERVICE_ID;
+      proxy_method POST;
       proxy_pass https://threescale_backend/services/$service_id/oauth_access_tokens.xml;
     }
 
@@ -88,6 +89,7 @@ http {
       proxy_set_header  Host "su1.3scale.net";
       set $provider_key CHANGE_ME_PROVIDER_KEY;
       set $service_id CHANGE_ME_SERVICE_ID;
+      proxy_method POST;
       proxy_pass https://threescale_backend/transactions.xml?provider_key=$provider_key&service_id=$service_id&transactions[0][access_token]=$arg_access_token&$usage;
     }
 


### PR DESCRIPTION
The report action and store token actions were explicitly set to be a post action as the lack of it was causing errors in the integration.