### PR TITLE
Fixed missing "end" in nginx.conf

### DIFF
--- a/oauth2/resource-owner-password-flow/no-token-generation/nginx.conf
+++ b/oauth2/resource-owner-password-flow/no-token-generation/nginx.conf
@@ -138,14 +138,15 @@ http {
           else
             local res2 = ngx.location.capture("/_threescale/oauth_report?access_token="..ngx.var.access_token, {method = ngx.HTTP_POST, share_all_vars = true})
             ngx.status = 200
-          ngx.header.content_length = 0
-          ngx.exit(ngx.HTTP_OK)
+            ngx.header.content_length = 0
+            ngx.exit(ngx.HTTP_OK)
           end
         else
           local res2 = ngx.location.capture("/_threescale/oauth_report?access_token="..ngx.var.access_token, {method = ngx.HTTP_POST, share_all_vars = true})
           ngx.status = 200
           ngx.header.content_length = 0
           ngx.exit(ngx.HTTP_OK)
+        end
       ';
     }
 


### PR DESCRIPTION
Hi,

I think there was a typo (missing "end" in a Lua block in nginx.conf file), here's a fix for that.

Cheers!
Sébastien Roccaserra.