### PR TITLE
Fix URL encoding of OAuth query params

### DIFF
--- a/oauth2/resource-owner-password-flow/no-token-generation/get_token.lua
+++ b/oauth2/resource-owner-password-flow/no-token-generation/get_token.lua
@@ -21,7 +21,10 @@ function get_token(params)
 
   if ts.required_params_present(required_params, params) and params['grant_type'] == 'password' then
     local res = ngx.location.capture("/_oauth/token",
-      { method = ngx.CHANGE_ME_HTTP_METHOD, args = "username="..params.username.."&password="..params.password..CHANGE_ME_ADDITIONAL_PARAMS} )
+      { method = ngx.CHANGE_ME_HTTP_METHOD,
+        args = { username = params.username, password = params.password, CHANGE_ME_ADDITIONAL_PARAMS = '' }
+      }
+    )
     if res.status ~= 200 then
       ngx.status = res.status
       ngx.header.content_type = "application/json; charset=utf-8"


### PR DESCRIPTION
Concatenating these strings without URL encoding them is not safe. Many non-alphanumeric characters (e.g. space, `+`, `%`) will break the upstream server. capture() assumes that `args` is properly encoded if you pass it a string, but will handle the encoding if you pass it a table instead.