### PR TITLE
Don't pass Accept-Encoding header through to upstream OAuth service

### DIFF
--- a/oauth2/resource-owner-password-flow/no-token-generation/nginx.conf
+++ b/oauth2/resource-owner-password-flow/no-token-generation/nginx.conf
@@ -67,6 +67,7 @@ http {
       proxy_set_header  X-Real-IP  $remote_addr;
       proxy_set_header  X-Forwarded-For $proxy_add_x_forwarded_for;
       proxy_set_header  Host $http_host;
+      more_clear_input_headers Accept-Encoding;
 
       proxy_redirect    off;
       proxy_max_temp_file_size 0;


### PR DESCRIPTION
Most modern clients support gzip encoding and automatically include an
`Accept-Encoding` header indicating so. Unfortunately, 3scale breaks
when the upstream OAuth service support gzip responses, because
`get_token.lua` blindly assumes the response is plaintext. Blocking the
`Accept-Encoding` header from reaching the upsteam service prevents
this.