### PR TITLE
Don't rewrite upstream token responses

### DIFF
--- a/oauth2/resource-owner-password-flow/no-token-generation/get_token.lua
+++ b/oauth2/resource-owner-password-flow/no-token-generation/get_token.lua
@@ -1,41 +1,43 @@
 local ts = require 'threescale_utils'
 
-local function store_token(client_id, token)
+local function store_token(client_id, body)
+  -- Extract token from response - assuming it's in json format
+  value = cjson.decode(body)
+  token = value.access_token
   local stored = ngx.location.capture("/_threescale/oauth_store_token",
     {method = ngx.HTTP_POST,
     body = "provider_key=" ..ngx.var.provider_key ..
     "&app_id=".. client_id ..
     "&token=".. token})
   if stored.status ~= 200 then
-    ngx.say("eeeerror")
+    ngx.say("error")
     ngx.exit(ngx.HTTP_OK)
   end
 
   ngx.header.content_type = "application/json; charset=utf-8"
-  ngx.say({'{"access_token": "'.. token .. '", "token_type": "bearer"}'})
+  ngx.say(body)
   ngx.exit(ngx.HTTP_OK)
 end
 
 function get_token(params)
   local required_params = {'username', 'password', 'grant_type', CHANGE_ME_ADDITIONAL_PARAMS}
+  local args
 
   if ts.required_params_present(required_params, params) and params['grant_type'] == 'password' then
-    local res = ngx.location.capture("/_oauth/token",
-      { method = ngx.CHANGE_ME_HTTP_METHOD, args = "username="..params.username.."&password="..params.password..CHANGE_ME_ADDITIONAL_PARAMS} )
-    if res.status ~= 200 then
-      ngx.status = res.status
-      ngx.header.content_type = "application/json; charset=utf-8"
-      ngx.print(res.body)
-      ngx.exit(ngx.HTTP_OK)
-    else
-      -- Extract token from response - assuming it's in json format
-      value = cjson.decode(res.body)
-      token = value.access_token
-      store_token(params.client_id, token)
-    end
+    args = "username="..params.username.."&password="..params.password.."&grant_type=password"
   else
     ngx.log(0, "NOPE")
-    ngx.exit(ngx.HTTP_FORBIDDEN)
+    return ngx.exit(ngx.HTTP_FORBIDDEN)
+  end
+
+  local res = ngx.location.capture("/_oauth/token", { method = ngx.CHANGE_ME_HTTP_METHOD, args = args } ) 
+  if res.status ~= 200 then
+    ngx.status = res.status
+    ngx.header.content_type = "application/json; charset=utf-8"
+    ngx.print(res.body)
+    ngx.exit(ngx.HTTP_OK)
+  else
+    store_token(params.client_id, res.body)
   end
 end
 


### PR DESCRIPTION
Manually reconstructing a token response is unnecessary and causes
complications. Most OAuth 2 services return additional fields such as
`expires_in` and `refresh_token`. Rather than require editing this file
to support additional fields, it makes more sense to just return the
upstream response after parsing out the token.